### PR TITLE
Update @sveltejs/package and migration changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 /build
 /.svelte-kit
 /package
+/dist
 .env
 .env.*
 !.env.example

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@sveltejs/adapter-auto": "^2.1.1",
     "@sveltejs/kit": "^1.27.4",
-    "@sveltejs/package": "^1.0.2",
+    "@sveltejs/package": "^2.3.10",
     "@types/html-to-text": "^9.0.4",
     "@types/pretty": "^2.0.3",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
@@ -62,5 +62,36 @@
     "svelte": "^5",
     "svelte-persisted-store": "^0.12.0",
     "tw-to-css": "0.0.12"
+  },
+  "files": ["dist"],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "svelte": "./dist/index.js",
+      "default":"./dist/index.js"
+    },
+    "./package.json": "./package.json",
+    "./components/Body.svelte": "./dist/components/Body.svelte",
+    "./components/Button.svelte": "./dist/components/Button.svelte",
+    "./components/Column.svelte": "./dist/components/Column.svelte",
+    "./components/Container.svelte": "./dist/components/Container.svelte",
+    "./components/Custom.svelte": "./dist/components/Custom.svelte",
+    "./components/Head.svelte": "./dist/components/Head.svelte",
+    "./components/Heading.svelte": "./dist/components/Heading.svelte",
+    "./components/Hr.svelte": "./dist/components/Hr.svelte",
+    "./components/Html.svelte": "./dist/components/Html.svelte",
+    "./components/Img.svelte": "./dist/components/Img.svelte",
+    "./components/Link.svelte": "./dist/components/Link.svelte",
+    "./components/Preview.svelte": "./dist/components/Preview.svelte",
+    "./components/Row.svelte": "./dist/components/Row.svelte",
+    "./components/Section.svelte": "./dist/components/Section.svelte",
+    "./components/Text.svelte": "./dist/components/Text.svelte",
+    "./preview": "./dist/preview/index.js",
+    "./preview/preview.svelte": "./dist/preview/preview.svelte",
+    "./utils": "./dist/utils/index.js",
+    "./vite": "./dist/vite/index.js",
+    "./vite/utils/inline-tailwind": "./dist/vite/utils/inline-tailwind.js",
+    "./vite/utils/string-utils": "./dist/vite/utils/string-utils.js",
+    "./vite/utils/tailwind-utils": "./dist/vite/utils/tailwind-utils.js"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: ^1.27.4
         version: 1.30.4(svelte@5.1.9)(vite@4.5.5)
       '@sveltejs/package':
-        specifier: ^1.0.2
-        version: 1.0.2(svelte@5.1.9)(typescript@4.9.5)
+        specifier: ^2.3.10
+        version: 2.3.10(svelte@5.1.9)(typescript@4.9.5)
       '@types/html-to-text':
         specifier: ^9.0.4
         version: 9.0.4
@@ -351,12 +351,12 @@ packages:
       svelte: ^3.54.0 || ^4.0.0-next.0 || ^5.0.0-next.0
       vite: ^4.0.0
 
-  '@sveltejs/package@1.0.2':
-    resolution: {integrity: sha512-VY9U+05d9uNFDj7ScKRlHORYlfPSHwJewBjV+V2RsnViexpLFPUrboC9SiPYDCpLnbeqwXerxhO6twGHUBGeIA==}
+  '@sveltejs/package@2.3.10':
+    resolution: {integrity: sha512-A4fQacgjJ7C/7oSmxR61/TdB14u6ecyMZ8V9JCR5Lol0bLj/PdJPU4uFodFBsKzO3iFiJMpNTgZZ+zYsYZNpUg==}
     engines: {node: ^16.14 || >=18}
     hasBin: true
     peerDependencies:
-      svelte: ^3.44.0
+      svelte: ^3.44.0 || ^4.0.0 || ^5.0.0-next.1
 
   '@sveltejs/vite-plugin-svelte-inspector@1.0.4':
     resolution: {integrity: sha512-zjiuZ3yydBtwpF3bj0kQNV0YXe+iKE545QGZVTaylW3eAzFr+pJ/cwK8lZEaRp4JtaJXhD5DyWAV4AxLh6DgaQ==}
@@ -588,6 +588,10 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
 
   clsx@1.2.1:
     resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
@@ -1357,6 +1361,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  readdirp@4.1.1:
+    resolution: {integrity: sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==}
+    engines: {node: '>= 14.18.0'}
+
   resend@2.0.0:
     resolution: {integrity: sha512-jAh0DN84ZjjmzGM2vMjJ1hphPBg1mG98dzopF7kJzmin62v8ESg4og2iCKWdkAboGOT2SeO5exbr/8Xh8gLddw==}
     engines: {node: '>=18'}
@@ -1536,8 +1544,8 @@ packages:
       typescript:
         optional: true
 
-  svelte2tsx@0.6.27:
-    resolution: {integrity: sha512-E1uPW1o6VsbRz+nUk3fznZ2lSmCITAJoNu8AYefWSvIwE2pSB01i5sId4RMbWNzfcwCQl1DcgGShCPcldl4rvg==}
+  svelte2tsx@0.7.34:
+    resolution: {integrity: sha512-WTMhpNhFf8/h3SMtR5dkdSy2qfveomkhYei/QW9gSPccb0/b82tjHvLop6vT303ZkGswU/da1s6XvrLgthQPCw==}
     peerDependencies:
       svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
       typescript: ^4.9.4 || ^5.0.0
@@ -1927,13 +1935,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/package@1.0.2(svelte@5.1.9)(typescript@4.9.5)':
+  '@sveltejs/package@2.3.10(svelte@5.1.9)(typescript@4.9.5)':
     dependencies:
-      chokidar: 3.6.0
+      chokidar: 4.0.3
       kleur: 4.1.5
       sade: 1.8.1
+      semver: 7.6.3
       svelte: 5.1.9
-      svelte2tsx: 0.6.27(svelte@5.1.9)(typescript@4.9.5)
+      svelte2tsx: 0.7.34(svelte@5.1.9)(typescript@4.9.5)
     transitivePeerDependencies:
       - typescript
 
@@ -2190,6 +2199,10 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.1
 
   clsx@1.2.1: {}
 
@@ -2932,6 +2945,8 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
+  readdirp@4.1.1: {}
+
   resend@2.0.0:
     dependencies:
       '@react-email/render': 0.0.9
@@ -3095,7 +3110,7 @@ snapshots:
       postcss-load-config: 4.0.2(postcss@8.4.47)
       typescript: 5.6.3
 
-  svelte2tsx@0.6.27(svelte@5.1.9)(typescript@4.9.5):
+  svelte2tsx@0.7.34(svelte@5.1.9)(typescript@4.9.5):
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2


### PR DESCRIPTION
Hello, this is the PR for #17 

Of course, a review is need to see that the package is resolving correctly all the components/utilities present.

Mainly the changes are:
- Migrating to `@sveltejs/package@2.3.10`.
- Add the export resolutions to the root package.json. The root package.json is now used instead of generating a new one