### PR TITLE
fix head string matcher

### DIFF
--- a/src/lib/vite/utils/inline-tailwind.ts
+++ b/src/lib/vite/utils/inline-tailwind.ts
@@ -212,7 +212,7 @@ function substituteHead(code: string, twClean: string) {
 	}
 
 	const stringAfterStart = code.substring(iS);
-	const stringToMatchBeforeHeadContent = '$$payload.out += `';
+	const stringToMatchBeforeHeadContent = '$$payload.out.push(`';
 	const indexStartHeadContent =
 		stringAfterStart.indexOf(stringToMatchBeforeHeadContent) +
 		stringToMatchBeforeHeadContent.length;


### PR DESCRIPTION
Svelte is now using `$$payload.out.push(` instead of `$$payload.out += `